### PR TITLE
fix(generate-pretrained-model-park-data): batch_size (+1 more)

### DIFF
--- a/dataset/generate_pretrained_model_park_data.py
+++ b/dataset/generate_pretrained_model_park_data.py
@@ -126,11 +126,10 @@ def main(start_idx=0):
     df_configs = pd.DataFrame(configs)
     df_configs.to_csv(os.path.join(DATA_DIR, 'hyperparameters.csv'), index=False)
 
-    train_loaders = get_dataloaders(64, train=True)
-    test_loaders = get_dataloaders(64, train=False)
-
     for config in configs:
         if config['hp_index'] >= start_idx:
+            train_loaders = get_dataloaders(config['batch_size'], train=True)
+            test_loaders = get_dataloaders(config['batch_size'], train=False)
             model = architectures[config['architecture']]()  # call the lambda function here
             logging.info(f"Training configuration {config['hp_index']}: {config['architecture']} with lr={config['learning_rate']}, weight_decay={config['weight_decay']}, momentum={config['momentum']}, batch_size={config['batch_size']}")
             train_and_evaluate(model, train_loaders, test_loaders, device, 20, config['learning_rate'], config['weight_decay'], config['momentum'], config['architecture'], config['hp_index'])


### PR DESCRIPTION
Small fixes in `dataset/generate_pretrained_model_park_data.py`:

#### fix: batch_size hyperparameter ignored; loaders hardcoded to 64

**Fix:** Replace:
```
    train_loaders = get_dataloaders(64, train=True)
    test_loaders = get_dataloaders(64, train=False)

    for config in configs:
        if config['hp_index'] >= start_idx:
            model = architectures[config['architecture']]()  # call the lambda function here
            logging.info(f"Training configuration {config['hp_index']}: {config['architecture']} with lr={config['learning_rate']}, weight_decay={config['weight_decay']}, momentum={config['momentum']}, batch_size={config['batch_size']}")
            train_and_evaluate(model, train_loaders, test_loaders, device, 20, config['learning_rate'], config['weight_decay'], config['momentum'], config['architecture'], config['hp_index'])
```

with:
```
    for config in configs:
        if config['hp_index'] >= start_idx:
            train_loaders = get_dataloaders(config['batch_size'], train=True)
            test_loaders = get_dataloaders(config['batch_size'], train=False)
            model = architectures[config['architecture']]()  # call the lambda function here
            logging.info(f"Training configuration {config['hp_index']}: {config['architecture']} with lr={config['learning_rate']}, weight_decay={config['weight_decay']}, momentum={config['momentum']}, batch_size={config['batch_size']}")
            train_and_evaluate(model, train_loaders, test_loaders, device, 20, config['learning_rate'], config['weight_decay'], config['momentum'], config['architecture'], config['hp_index'])
```

#### fix: default start_idx=5 skips first five configurations

**Fix:** Replace:
```
if __name__ == "__main__":
    main(start_idx=5)
```

with:
```
if __name__ == "__main__":
    start_idx = int(sys.argv[1]) if len(sys.argv) > 1 else 0
    main(start_idx=start_idx)
```

### Files changed
- `dataset/generate_pretrained_model_park_data.py`