### PR TITLE
fix: PositionwiseFeedForward ignores activation arg

### DIFF
--- a/dataset/pretrained_model_park/models/transformer.py
+++ b/dataset/pretrained_model_park/models/transformer.py
@@ -33,7 +33,8 @@ class PositionwiseFeedForward(nn.Module):
         self.lin1 = nn.Linear(d_model, d_ff)
         self.lin2 = nn.Linear(d_ff, d_model)
         self.dropout = nn.Dropout(dropout)
-        self.activation = nn.ReLU()
+        self.activation = {'relu': nn.ReLU,
+                            'gelu': nn.GELU}[activation]()
         
     def forward(self, x):
         return x + self.lin2(self.dropout(self.activation(self.lin1(x))))


### PR DESCRIPTION
### Problem
fix: PositionwiseFeedForward ignores activation arg

### Fix
Replace:
```
    def __init__(self, d_model, d_ff, dropout=.1, activation='relu'):
        super().__init__()
        self.lin1 = nn.Linear(d_model, d_ff)
        self.lin2 = nn.Linear(d_ff, d_model)
        self.dropout = nn.Dropout(dropout)
        self.activation = nn.ReLU()
        
    def forward(self, x):
        return x + self.lin2(self.dropout(self.activation(self.lin1(x))))
```

with:
```
    def __init__(self, d_model, d_ff, dropout=.1, activation='relu'):
        super().__init__()
        self.lin1 = nn.Linear(d_model, d_ff)
        self.lin2 = nn.Linear(d_ff, d_model)
        self.dropout = nn.Dropout(dropout)
        self.activation = {'relu': nn.ReLU,
                            'gelu': nn.GELU}[activation]()
        
    def forward(self, x):
        return x + self.lin2(self.dropout(self.activation(self.lin1(x))))
```

### Files changed
- `dataset/pretrained_model_park/models/transformer.py`