### PR TITLE
fix(interface): get_pytorch_model crashes when checkpoint (+1 more)

### DIFF
--- a/dataset/simple_cnn_park/interface.py
+++ b/dataset/simple_cnn_park/interface.py
@@ -90,6 +90,8 @@ class SimpleCNNParkInterface:
     def get_pytorch_model(self, hp_index, epoch):
         """ Load a PyTorch model checkpoint for a specific configuration and epoch, then load the state dict into SmallCNN """
         loaded_checkpoint = self.load_checkpoint(hp_index, epoch)
+        if loaded_checkpoint is None:
+            raise FileNotFoundError(f"No checkpoint found for hp_index={hp_index}, epoch={epoch}")
         model = SmallCNN()
         model.load_state_dict(loaded_checkpoint)
         return model
@@ -206,7 +208,10 @@ class SimpleCNNParkInterface:
         best_config_key = next(iter(best_configs))  # Gets the first key in the dictionary
         best_performance = best_configs[best_config_key][metric]
 
-        regret = best_performance - best_seen_performance
+        if minimize:
+            regret = best_seen_performance - best_performance
+        else:
+            regret = best_performance - best_seen_performance
         return regret
 
     def get_ground_truth_rankings(self, metric='test_accuracy', epoch=None, minimize=False):


### PR DESCRIPTION
Small fixes in `dataset/simple_cnn_park/interface.py`:

#### fix: get_pytorch_model crashes when checkpoint is missing

**Fix:** Replace:
```
        loaded_checkpoint = self.load_checkpoint(hp_index, epoch)
        model = SmallCNN()
        model.load_state_dict(loaded_checkpoint)
        return model
```

with:
```
        loaded_checkpoint = self.load_checkpoint(hp_index, epoch)
        if loaded_checkpoint is None:
            raise FileNotFoundError(f"No checkpoint found for hp_index={hp_index}, epoch={epoch}")
        model = SmallCNN()
        model.load_state_dict(loaded_checkpoint)
        return model
```

#### fix: regret sign is wrong for minimization metrics

**Fix:** Replace:
```
        regret = best_performance - best_seen_performance
        return regret
```

with:
```
        if minimize:
            regret = best_seen_performance - best_performance
        else:
            regret = best_performance - best_seen_performance
        return regret
```

### Files changed
- `dataset/simple_cnn_park/interface.py`