### PR TITLE
fix(net-makers): make_small_cnn feeds 4D tensor into (+1 more)

### DIFF
--- a/experiments/gmn/graph_construct/net_makers.py
+++ b/experiments/gmn/graph_construct/net_makers.py
@@ -31,6 +31,7 @@ def make_small_cnn():
                           nn.Conv2d(16, 16, 3),
                           nn.Conv2d(16, 16, 3),
                           nn.AdaptiveAvgPool2d((1,1)),
+                          Flatten(),
                           nn.Linear(16, 10))
     return model
 
@@ -175,7 +176,8 @@ def make_deepsets(conv_layers=2, fc_layers=2, hidden_dim=32, in_dim=3, num_class
 
 def make_resnet(conv_layers=2, hidden_dim=32, in_dim=3, num_classes=10, activation='relu'):
     layers = []
-    activation_builder = nn.ReLU
+    activation_builder = {'relu': nn.ReLU,
+                          'gelu': nn.GELU}[activation]
     norm_builder = nn.BatchNorm2d
 
     layers.append(nn.Conv2d(in_dim, hidden_dim // 2, 5))


### PR DESCRIPTION
Small fixes in `experiments/gmn/graph_construct/net_makers.py`:

#### fix: make_small_cnn feeds 4D tensor into Linear without flattening

**Fix:** Replace:
```
    model = nn.Sequential(nn.Conv2d(1, 16, 3),
                          nn.Conv2d(16, 16, 3),
                          nn.Conv2d(16, 16, 3),
                          nn.AdaptiveAvgPool2d((1,1)),
                          nn.Linear(16, 10))
```

with:
```
    model = nn.Sequential(nn.Conv2d(1, 16, 3),
                          nn.Conv2d(16, 16, 3),
                          nn.Conv2d(16, 16, 3),
                          nn.AdaptiveAvgPool2d((1,1)),
                          Flatten(),
                          nn.Linear(16, 10))
```

#### fix: make_resnet ignores activation and always uses ReLU

**Fix:** Replace:
```
    activation_builder = nn.ReLU
    norm_builder = nn.BatchNorm2d
```

with:
```
    activation_builder = {'relu': nn.ReLU,
                          'gelu': nn.GELU}[activation]
    norm_builder = nn.BatchNorm2d
```

### Files changed
- `experiments/gmn/graph_construct/net_makers.py`