### PR TITLE
fix(surrogates): NFN submodule is recreated each forward (+3 more)

### DIFF
--- a/experiments/surrogates.py
+++ b/experiments/surrogates.py
@@ -1234,7 +1234,7 @@ class RandomSearchSurrogateModel:
 
     def suggest_next_hp_index(self, used_indices):
         """Randomly suggest a new hyperparameter index from available indices."""
-        available_configs = [idx for idx in self.available_indices if used_indices[idx] < self.data_interface.max_budget]
+        available_configs = [idx for idx in self.available_indices if used_indices.get(idx, 0) < self.data_interface.max_budget]
         if not available_configs:
             raise Exception("No more unique configurations to suggest.")
         index = random.choice(available_configs)


### PR DESCRIPTION
Small fixes in `experiments/surrogates.py`:

#### fix: NFN submodule is recreated each forward and never registered

**Fix:** Replace:
```
    def make_nfn(self, network_spec, nfn_channels=32):
        return nn.Sequential(
            # io_embed: encode the input and output dimensions of the weight space feature
            NPLinear(network_spec, 1, nfn_channels, io_embed=True),
            TupleOp(nn.ReLU()),
            NPLinear(network_spec, nfn_channels, nfn_channels, io_embed=True),
            TupleOp(nn.ReLU()),
            HNPPool(network_spec),
            nn.Flatten(start_dim=-2),
            nn.Linear(nfn_channels * HNPPool.get_num_outs(network_spec), self.configuration['state_dict_nr_channels'])
        ).to(self.device)

    def process_state_dicts(self, state_dicts, architectures):
        wts_and_bs = []
        for state_dict in state_dicts:
            wts_and_bs.append(state_dict_to_tensors(state_dict))
        # Here we manually collate weights and biases (stack into batch dim).
        # When using a dataloader, the collate is done automatically.
        wtfeat = WeightSpaceFeatures(*default_collate(wts_and_bs)).to(self.device)
        network_spec = network_spec_from_wsfeat(wtfeat)
        nfn = self.make_nfn(network_spec)
        out = nfn(wtfeat)
        return out
```

with:
```
    def make_nfn(self, network_spec, nfn_channels=32):
        return nn.Sequential(
            # io_embed: encode the input and output dimensions of the weight space feature
            NPLinear(network_spec, 1, nfn_channels, io_embed=True),
            TupleOp(nn.ReLU()),
            NPLinear(network_spec, nfn_channels, nfn_channels, io_embed=True),
            TupleOp(nn.ReLU()),
            HNPPool(network_spec),
            nn.Flatten(start_dim=-2),
            nn.Linear(nfn_channels * HNPPool.get_num_outs(network_spec), self.configuration['state_dict_nr_channels'])
        ).to(self.device)

    def process_state_dicts(self, state_dicts, architectures):
        wts_and_bs = []
        for state_dict in state_dicts:
            wts_and_bs.append(state_dict_to_tensors(state_dict))
        # Here we manually collate weights and biases (stack into batch dim).
        # When using a dataloader, the collate is done automatically.
        wtfeat = WeightSpaceFeatures(*default_collate(wts_and_bs)).to(self.device)
        network_spec = network_spec_from_wsfeat(wtfeat)
        if not hasattr(self, 'nfn'):
            self.nfn = self.make_nfn(network_spec)
        out = self.nfn(wtfeat)
        return out
```

#### fix: GMN fallback uses undefined self.expected_feature_dim

**Fix:** Replace:
```
        if graph_features.dim() == 1:  # If it's a scalar per graph, expand or replicate
            graph_features = graph_features.view(-1, 1).repeat(1, self.expected_feature_dim)  # Adjust `expected_feature_dim` as needed
```

with:
```
        if graph_features.dim() == 1:  # If it's a scalar per graph, expand or replicate
            expected_feature_dim = self.configuration.get('gmn_nr_channels', graph_features.numel())
            graph_features = graph_features.view(-1, 1).repeat(1, expected_feature_dim)
```

#### fix: random search KeyError when indices are unseen

**Fix:** Replace:
```
    def suggest_next_hp_index(self, used_indices):
        """Randomly suggest a new hyperparameter index from available indices."""
        available_configs = [idx for idx in self.available_indices if used_indices[idx] < self.data_interface.max_budget]
```

with:
```
    def suggest_next_hp_index(self, used_indices):
        """Randomly suggest a new hyperparameter index from available indices."""
        available_configs = [idx for idx in self.available_indices if used_indices.get(idx, 0) < self.data_interface.max_budget]
```

#### fix: layer name mismatch in Nfn and DyHpo extractors

**Fix:** Replace:
```
        for i in range(2, self.nr_layers):
            setattr(
                self,
                f'fc{i + 1}',
                nn.Linear(configuration[f'layer{i - 1}_units'], configuration[f'layer{i}_units']),
            )
            setattr(
                self,
                f'bn{i + 1}',
                nn.BatchNorm1d(configuration[f'layer{i}_units']),
            )
        setattr(
            self,
            f'fc{self.nr_layers}',
            nn.Linear(
                configuration[f'layer{self.nr_layers - 1}_units'] +
                (configuration['cnn_nr_channels'] if self.configuration['use_cnn'] else 0) + # accounting for the learning curve features
                (configuration['state_dict_nr_channels'] if self.configuration['use_weights'] else 0),  # accounting for the state dict features
                configuration[f'layer{self.nr_layers}_units']
            ),
        )
```

with:
```
        for i in range(2, self.nr_layers):
            setattr(
                self,
                f'fc{i}',
                nn.Linear(configuration[f'layer{i - 1}_units'], configuration[f'layer{i}_units']),
            )
            setattr(
                self,
                f'bn{i}',
                nn.BatchNorm1d(configuration[f'layer{i}_units']),
            )
        setattr(
            self,
            f'fc{self.nr_layers}',
            nn.Linear(
                configuration[f'layer{self.nr_layers - 1}_units'] +
                (configuration['cnn_nr_channels'] if self.configuration['use_cnn'] else 0) + # accounting for the learning curve features
                (configuration['state_dict_nr_channels'] if self.configuration['use_weights'] else 0),  # accounting for the state dict features
                configuration[f'layer{self.nr_layers}_units']
            ),
        )
```

### Files changed
- `experiments/surrogates.py`