### PR TITLE
fix: random-search class returned as feature extractor is incompatible

### DIFF
--- a/experiments/surrogates.py
+++ b/experiments/surrogates.py
@@ -451,8 +451,6 @@ def get_feature_extractor(experiment_type):
         return FlatFeatureExtractor
     elif experiment_type == "dyhpo":
         return DyHpoFeatureExtractor
-    elif experiment_type == "random-search":
-        return RandomSearchSurrogateModel
 
 class FmsSurrogateModel():
     """The GP + Feature Extractor model."""


### PR DESCRIPTION
### Problem
fix: random-search class returned as feature extractor is incompatible

### Fix
Replace:
```
def get_feature_extractor(experiment_type):
    if experiment_type == "fms":
        return GmnFeatureExtractor
    elif experiment_type == "fms-nfn":
        return NfnFeatureExtractor
    elif experiment_type == "fms-flat":
        return FlatFeatureExtractor
    elif experiment_type == "dyhpo":
        return DyHpoFeatureExtractor
    elif experiment_type == "random-search":
        return RandomSearchSurrogateModel
```

with:
```
def get_feature_extractor(experiment_type):
    if experiment_type == "fms":
        return GmnFeatureExtractor
    elif experiment_type == "fms-nfn":
        return NfnFeatureExtractor
    elif experiment_type == "fms-flat":
        return FlatFeatureExtractor
    elif experiment_type == "dyhpo":
        return DyHpoFeatureExtractor
```

### Files changed
- `experiments/surrogates.py`