### PR TITLE
fix: setup.py parses commented-out and blank requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,9 +15,11 @@ from setuptools import find_packages, setup
 
 def requirements():
     list_requirements = []
-    with open("requirements.txt") as f:
+    with open("requirements.txt", encoding="utf-8") as f:
         for line in f:
-            list_requirements.append(line.rstrip())
+            line = line.strip()
+            if line and not line.startswith("#"):
+                list_requirements.append(line)
     return list_requirements
 
 


### PR DESCRIPTION
### Problem
fix: setup.py parses commented-out and blank requirements

### Fix
Replace:
```
def requirements():
    list_requirements = []
    with open("requirements.txt") as f:
        for line in f:
            list_requirements.append(line.rstrip())
    return list_requirements
```

with:
```
def requirements():
    list_requirements = []
    with open("requirements.txt", encoding="utf-8") as f:
        for line in f:
            line = line.strip()
            if line and not line.startswith("#"):
                list_requirements.append(line)
    return list_requirements
```

### Files changed
- `setup.py`