### PR TITLE
fix: duplicate PositionwiseFeedForward class ignores activation

### DIFF
--- a/experiments/gmn/graph_construct/layers.py
+++ b/experiments/gmn/graph_construct/layers.py
@@ -108,17 +108,6 @@ class SinPosEnc(nn.Module):
         return x + pe
 
 
-class PositionwiseFeedForward(nn.Module):
-    def __init__(self, d_model, d_ff, dropout=.1, activation='relu'):
-        super().__init__()
-        self.lin1 = nn.Linear(d_model, d_ff)
-        self.lin2 = nn.Linear(d_ff, d_model)
-        self.dropout = nn.Dropout(dropout)
-        self.activation = nn.ReLU()
-        
-    def forward(self, x):
-        return x + self.lin2(self.dropout(self.activation(self.lin1(x))))
-
 class EquivSetLinear(nn.Module):
     ''' Equivariant DeepSets linear layer 
         Input is B x D x N


### PR DESCRIPTION
### Problem
fix: duplicate PositionwiseFeedForward class ignores activation

### Fix
Apply patch:
```diff
--- a/experiments/gmn/graph_construct/layers.py
+++ b/experiments/gmn/graph_construct/layers.py
@@ -61,6 +61,3 @@
     def forward(self, x):
         return x + self.attn(x, x, x, need_weights=False)[0]
 
 
-class PositionwiseFeedForward(nn.Module):
-    def __init__(self, d_model, d_ff, dropout=.1, activation='relu'):
-        super().__init__()
-        self.lin1 = nn.Linear(d_model, d_ff)
-        self.lin2 = nn.Linear(d_ff, d_model)
-        self.dropout = nn.Dropout(dropout)
-        self.activation = nn.ReLU()
-        
-    def forward(self, x):
-        return x + self.lin2(self.dropout(self.activation(self.lin1(x))))
-
 class EquivSetLinear(nn.Module):
```

### Files changed
- `experiments/gmn/graph_construct/layers.py`